### PR TITLE
feat - add collection support for collections. ONLY Equals operator

### DIFF
--- a/QueryKit.UnitTests/FilterParserTests.cs
+++ b/QueryKit.UnitTests/FilterParserTests.cs
@@ -568,7 +568,7 @@ public class FilterParserTests
         var input = $"Ingredients.Preparations.Text == \"{prepText}\"";
         var config = new QueryKitConfiguration(settings =>
         {
-            settings.Property<Recipe>(x => x.Ingredients.Select(y => y.Name)).PreventSort();
+            settings.Property<Recipe>(x => x.Ingredients.SelectMany(y => y.Preparations).Select(y=> y.Text)).PreventSort();
         });
         var filterExpression = FilterParser.ParseFilter<Recipe>(input, config);
 

--- a/QueryKit.WebApiTestProject/Entities/Ingredients/Ingredient.cs
+++ b/QueryKit.WebApiTestProject/Entities/Ingredients/Ingredient.cs
@@ -6,6 +6,11 @@ using System.Text.Json.Serialization;
 using Models;
 using Recipes;
 
+public class IngredientPreparation
+{
+    public string Text { get; set; }
+}
+
 public class Ingredient : BaseEntity
 {
     public string Name { get; private set; }
@@ -16,11 +21,12 @@ public class Ingredient : BaseEntity
 
     public string Measure { get; private set; }
 
+    public List<IngredientPreparation> Preparations { get; set; } = new();
+
     [JsonIgnore, IgnoreDataMember]
     [ForeignKey("Recipe")]
     public Guid RecipeId { get; private set; }
     public Recipe Recipe { get; private set; }
-
 
     public static Ingredient Create(IngredientForCreation ingredientForCreation)
     {

--- a/QueryKit.WebApiTestProject/Entities/Recipes/Recipe.cs
+++ b/QueryKit.WebApiTestProject/Entities/Recipes/Recipe.cs
@@ -38,6 +38,10 @@ public class Recipe : BaseEntity
     [JsonIgnore, IgnoreDataMember]
     public IReadOnlyCollection<Ingredient> Ingredients => _ingredients.AsReadOnly();
 
+    public void AddIngredient(Ingredient ingredient)
+    {
+        _ingredients.Add(ingredient);
+    }
 
     public static Recipe Create(RecipeForCreation recipeForCreation)
     {

--- a/QueryKit/Operators/ComparisonOperator.cs
+++ b/QueryKit/Operators/ComparisonOperator.cs
@@ -129,6 +129,27 @@ public abstract class ComparisonOperator : SmartEnum<ComparisonOperator>
                 );
             }
 
+            if (left.Type.IsGenericType && left.Type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                // create the x parameter
+                var xParameter = Expression.Parameter(left.Type.GetGenericArguments()[0], "x");
+
+                // create the x => x == right lambda
+                var anyLambda = Expression.Lambda(
+                    Expression.Equal(xParameter, right),
+                    xParameter
+                );
+
+                // get the .Any method
+                var anyMethod = typeof(Enumerable)
+                    .GetMethods()
+                    .Single(m => m.Name == "Any" && m.GetParameters().Length == 2)
+                    .MakeGenericMethod(left.Type.GetGenericArguments()[0]);
+
+                // append an .Any(x => x == right) expression
+                return Expression.Call(anyMethod, left, anyLambda);
+            }
+
             return Expression.Equal(left, right);
         }
     }

--- a/QueryKit/QueryKitPropertyMappings.cs
+++ b/QueryKit/QueryKitPropertyMappings.cs
@@ -48,6 +48,18 @@ public class QueryKitPropertyMappings
 
     private static string GetFullPropertyPath(Expression? expression)
     {
+        if (expression!.NodeType == ExpressionType.Call)
+        {
+            var call = (MethodCallExpression)expression;
+            if (call.Method.DeclaringType == typeof(Enumerable) && call.Method.Name == "Select" ||
+                call.Method.DeclaringType == typeof(Queryable) && call.Method.Name == "Select")
+            {
+                var propertyPath = GetFullPropertyPath(call.Arguments[1]);
+                var prevPath = GetFullPropertyPath(call.Arguments[0]);
+                return $"{prevPath}.{propertyPath}";
+            }
+        }
+
         if (expression!.NodeType == ExpressionType.Lambda)
         {
             var lambda = (LambdaExpression)expression;

--- a/QueryKit/QueryKitPropertyMappings.cs
+++ b/QueryKit/QueryKitPropertyMappings.cs
@@ -52,7 +52,9 @@ public class QueryKitPropertyMappings
         {
             var call = (MethodCallExpression)expression;
             if (call.Method.DeclaringType == typeof(Enumerable) && call.Method.Name == "Select" ||
-                call.Method.DeclaringType == typeof(Queryable) && call.Method.Name == "Select")
+                call.Method.DeclaringType == typeof(Queryable) && call.Method.Name == "Select" ||
+                call.Method.DeclaringType == typeof(Enumerable) && call.Method.Name == "SelectMany" ||
+                call.Method.DeclaringType == typeof(Queryable) && call.Method.Name == "SelectMany")
             {
                 var propertyPath = GetFullPropertyPath(call.Arguments[1]);
                 var prevPath = GetFullPropertyPath(call.Arguments[0]);


### PR DESCRIPTION
@pdevito3 This is an extremely rough idea and will need to be rewritten. But it adds support for collections. I have only added support for the equals operator. If you like this route we would need to assess what the best linq statements are for each operator.

I'm not sure I like that we would need to alter every operator to support Collections but I can't see another way to create the Expressions on an IEnumable. 

For instance `Ingredients.Preparations.Text == "<VALUE>"` on a `Recipe` would have to translate to either:
```
.Where(x => x.Ingredients.Any(y => y.Preparations.Any(z => z.Text == "<VALUE>")))
.Where(x => x.Ingredients.SelectMany(y => y.Preparations).Select(y => y.Text).Any(y => y == "<VALUE>"))
```
I opted for selecting the nested property and then applying the operator to avoid nested expressions., which would require you to know the operator before you start or some complex evaluation/manipulation of the expression after the "left" expression had been calculated.