### PR TITLE
fix: fixing issue #19: Configuration throwing exception related to No…

### DIFF
--- a/QueryKit/Configuration/QueryKitConfiguration.cs
+++ b/QueryKit/Configuration/QueryKitConfiguration.cs
@@ -87,6 +87,7 @@ public class QueryKitConfiguration : IQueryKitConfiguration
         NotEndsWithOperator = settings.NotEndsWithOperator;
         InOperator = settings.InOperator;
         SoundsLikeOperator = settings.SoundsLikeOperator;
+        NotInOperator = settings.NotInOperator;
         DoesNotSoundLikeOperator = settings.DoesNotSoundLikeOperator;
         CaseInsensitiveAppendix = settings.CaseInsensitiveAppendix;
         AndOperator = settings.AndOperator;

--- a/QueryKit/Configuration/QueryKitSettings.cs
+++ b/QueryKit/Configuration/QueryKitSettings.cs
@@ -19,6 +19,7 @@ public class QueryKitSettings
     public string NotStartsWithOperator { get; set; } = ComparisonOperator.NotStartsWithOperator().Operator();
     public string NotEndsWithOperator { get; set; } = ComparisonOperator.NotEndsWithOperator().Operator();
     public string InOperator { get; set; } = ComparisonOperator.InOperator().Operator();
+    public string NotInOperator { get; set; } = ComparisonOperator.NotInOperator().Operator();
     public string SoundsLikeOperator { get; set; } = ComparisonOperator.SoundsLikeOperator().Operator();
     public string DoesNotSoundLikeOperator { get; set; } = ComparisonOperator.DoesNotSoundLikeOperator().Operator();
     public string HasCountEqualToOperator { get; set; } = ComparisonOperator.HasCountEqualToOperator().Operator();


### PR DESCRIPTION
After some inspecting, I was able to completely solve the exception for my example provided on issue #19.
This PR was the result.

### The behavior before
On ParseFilter, called ReplaceComparisonAliases, then called GetAliasMatches.
On GetAliasMatches, in this line:

```cs
        if(aliases.NotInOperator != NotInOperator().Operator())
        {
            matches.Add(new ComparisonAliasMatch { Alias = aliases.NotInOperator, Operator = NotInOperator().Operator() });
            matches.Add(new ComparisonAliasMatch { Alias = $"{aliases.NotInOperator}{caseInsensitiveAppendix}", Operator = $"{NotInOperator(true).Operator()}" });
        }
```

It added to `matches` even when not specifying an alias for `NotInOperator`, because `aliases.NotInOperator` was `null`.

Then, in the _ReplaceComparisonAliases_ method, line `var escapedAlias = Regex.Escape(comparisonAliasMatch.Alias);` throws the exception.

### The behavior now
As the NotInOperator is now assigned and not null, the condition on the if is not true (because I didn't provide a custom alias).
Now, the foreach doesn't throws an exception.


### Tests
**Before**
![tests-before](https://github.com/pdevito3/QueryKit/assets/17142585/c7b57077-8f09-47ac-b8eb-e0652054ce28)
**After**
![tests-after](https://github.com/pdevito3/QueryKit/assets/17142585/38b8ead0-b86f-47fc-aceb-43a736bebc51)
