### PR TITLE
feat: add base QueryKitException

### DIFF
--- a/QueryKit/Exceptions/ParsingException.cs
+++ b/QueryKit/Exceptions/ParsingException.cs
@@ -2,7 +2,7 @@ namespace QueryKit.Exceptions;
 
 public sealed class ParsingException : Exception
 {
-    public ParsingException(Exception exception) 
+    public ParsingException(Exception exception)
         : base($"There was a parsing failure, likely due to an invalid comparison or logical operator. You may also be missing double quotes surrounding a string or guid.", exception)
     {
     }

--- a/QueryKit/Exceptions/QueryKitDbContextTypeException.cs
+++ b/QueryKit/Exceptions/QueryKitDbContextTypeException.cs
@@ -1,8 +1,8 @@
 namespace QueryKit.Exceptions;
 
-public sealed class QueryKitDbContextTypeException : Exception
+public sealed class QueryKitDbContextTypeException : QueryKitException
 {
-    public QueryKitDbContextTypeException(string specificMessage) 
+    public QueryKitDbContextTypeException(string specificMessage)
         : base($"There no DbContext type provided in your QueryKit config, but one was needed for this operation. {specificMessage}")
     {
     }

--- a/QueryKit/Exceptions/QueryKitException.cs
+++ b/QueryKit/Exceptions/QueryKitException.cs
@@ -1,0 +1,10 @@
+namespace QueryKit.Exceptions;
+
+/// <summary>
+/// Base QueryKit exception, all exceptions thrown by QueryKit inherit this.
+/// </summary>
+public class QueryKitException : Exception
+{
+    public QueryKitException(string message, Exception exception) : base(message, exception) {}
+    public QueryKitException(string message) : base(message) {}
+}

--- a/QueryKit/Exceptions/QueryKitParsingException.cs
+++ b/QueryKit/Exceptions/QueryKitParsingException.cs
@@ -1,8 +1,8 @@
 namespace QueryKit.Exceptions;
 
-public sealed class QueryKitParsingException : Exception
+public sealed class QueryKitParsingException : QueryKitException
 {
-    public QueryKitParsingException(string message) 
+    public QueryKitParsingException(string message)
         : base(message)
     {
     }

--- a/QueryKit/Exceptions/SortParsingException.cs
+++ b/QueryKit/Exceptions/SortParsingException.cs
@@ -1,8 +1,8 @@
 namespace QueryKit.Exceptions;
 
-public sealed class SortParsingException : Exception
+public sealed class SortParsingException : QueryKitException
 {
-    public SortParsingException(string propertyName) 
+    public SortParsingException(string propertyName)
         : base($"Parsing failed during sorting. '{propertyName}' was not recognized.")
     {
     }

--- a/QueryKit/Exceptions/SoundsLikeNotImplementedException.cs
+++ b/QueryKit/Exceptions/SoundsLikeNotImplementedException.cs
@@ -1,8 +1,8 @@
 namespace QueryKit.Exceptions;
 
-public sealed class SoundsLikeNotImplementedException : Exception
+public sealed class SoundsLikeNotImplementedException : QueryKitException
 {
-    public SoundsLikeNotImplementedException(string dbContextType) 
+    public SoundsLikeNotImplementedException(string dbContextType)
         : base($"The DbContext type {dbContextType} does not have a SoundsLike method.")
     {
     }

--- a/QueryKit/Exceptions/UnknownFilterPropertyException.cs
+++ b/QueryKit/Exceptions/UnknownFilterPropertyException.cs
@@ -1,8 +1,8 @@
 namespace QueryKit.Exceptions;
 
-public sealed class UnknownFilterPropertyException : Exception
+public sealed class UnknownFilterPropertyException : QueryKitException
 {
-    public UnknownFilterPropertyException(string propertyName) 
+    public UnknownFilterPropertyException(string propertyName)
         : base($"The filter property '{propertyName}' was not recognized.")
     {
     }

--- a/README.md
+++ b/README.md
@@ -419,7 +419,9 @@ var people = _dbContext.People
 
 If you want to capture errors to easily throw a `400`, you can add error handling around these exceptions:
 
-* A `FilterParsingException` will be thrown when there is an invalid operator or bad syntax is used (e.g. not using double quotes around a string or guid).
+* A `QueryKitException` is the base class for all of the exceptions listed below. This can be caught to catch
+any exception thrown by QueryKit.
+* A `ParsingException` will be thrown when there is an invalid operator or bad syntax is used (e.g. not using double quotes around a string or guid).
 * An `UnknownFilterPropertyException` will be thrown if a property is not recognized during filtering
 * A `SortParsingException` will be thrown if a property or operation is not recognized during sorting
 * A `QueryKitDbContextTypeException` will be thrown when trying to use a `DbContext` specific workflow without passing that context (e.g. SoundEx)


### PR DESCRIPTION
Resolves #25.

I've added in a new `QueryKitException` exception class, and updated the existing exceptions to inherit from it.

I've added some documentation to cover this new exception base class, and I've updated the documentation which referred to `FilterParsingException` which I think should have been `ParsingException`.

If I've done anything incorrect with this pull request and contribution let me know and I'll get it fixed!

Thanks.