### PR TITLE
fix: catch invalid enums

### DIFF
--- a/QueryKit.IntegrationTests/Tests/DatabaseSortingTests.cs
+++ b/QueryKit.IntegrationTests/Tests/DatabaseSortingTests.cs
@@ -3,6 +3,7 @@ namespace QueryKit.IntegrationTests.Tests;
 using Bogus;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using QueryKit.Exceptions;
 using SharedTestingHelper.Fakes;
 using WebApiTestProject.Entities;
 
@@ -165,7 +166,7 @@ public class DatabaseSortingTests : TestBase
         var act = () => appliedQueryable.ToListAsync();
 
         // Assert
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<ParsingException>();
     }
     
     [Fact]

--- a/QueryKit.UnitTests/FilterParserTests.cs
+++ b/QueryKit.UnitTests/FilterParserTests.cs
@@ -799,5 +799,14 @@ public class FilterParserTests
         filterExpression.ToString().Should()
             .Be(""""x => x.Tags.Any(z => (z.ToLower() != "winner".ToLower()))"""");
     }
+    
+    [Fact]
+    public void can_throw_exception_when_invalid_enum_value()
+    {
+        var input = $"""BirthMonth == invalid""";
+        var act = () => FilterParser.ParseFilter<TestingPerson>(input);
+        act.Should().Throw<ParsingException>()
+        .WithMessage("There was a parsing failure, likely due to an invalid comparison or logical operator. You may also be missing double quotes surrounding a string or guid.");
+    }
 }
     

--- a/QueryKit/FilterParser.cs
+++ b/QueryKit/FilterParser.cs
@@ -31,6 +31,9 @@ public static class FilterParser
         {
             expr = ExprParser<T>(parameter, config).End().Parse(input);
         }
+        catch (InvalidOperationException e) {
+            throw new ParsingException(e);
+        }
         catch (ParseException e)
         {
             throw new ParsingException(e);
@@ -314,7 +317,12 @@ public static class FilterParser
                 return Expression.Constant(null, rawType);
             }
             
-            var enumValue = Enum.Parse(enumType, right);
+            var parsed = Enum.TryParse(enumType, right, out var enumValue);
+            if (!parsed) 
+            {
+                throw new InvalidOperationException($"Unsupported value '{right}' for type '{targetType.Name}'");
+            }
+            
             var constant = Expression.Constant(enumValue, enumType);
 
             if (rawType == enumType) return constant;


### PR DESCRIPTION
Resolves #27.

Switches out `Enum.Parse` for `Enum.TryParse` and throws an exception if the enum parsing fails rather than a `System.ArgumentException`.

Catches the `InvalidOperationException` and re-throws it as a `ParserException` for consistency with the other exceptions.