### PR TITLE
Fix GitHub actions and unit tests

### DIFF
--- a/.github/workflows/querykit-integration-tests.yaml
+++ b/.github/workflows/querykit-integration-tests.yaml
@@ -20,5 +20,5 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
       - name: Test
-        working-directory: QueryKit/tests/QueryKit.IntegrationTests
+        working-directory: QueryKit.IntegrationTests
         run: dotnet test --no-restore --verbosity minimal

--- a/.github/workflows/querykit-unit-tests.yaml
+++ b/.github/workflows/querykit-unit-tests.yaml
@@ -20,5 +20,5 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
       - name: Test
-        working-directory: QueryKit/tests/QueryKit.UnitTests
+        working-directory: QueryKit.UnitTests
         run: dotnet test --no-restore --verbosity minimal

--- a/QueryKit.IntegrationTests/Tests/DatabaseFilteringTests.cs
+++ b/QueryKit.IntegrationTests/Tests/DatabaseFilteringTests.cs
@@ -967,4 +967,104 @@ public class DatabaseFilteringTests : TestBase
         people.Count.Should().Be(1);
         people[0].Id.Should().Be(fakePersonOne.Id);
     }
+    
+    [Fact]
+    public async Task can_filter_by_enum_name()
+    {
+        // Arrange
+        var testingServiceScope = new TestingServiceScope();
+        var faker = new Faker();
+        var fakePersonOne = new FakeTestingPersonBuilder()
+            .WithTitle(faker.Lorem.Sentence())
+            .WithBirthMonth(BirthMonthEnum.January)
+            .Build();
+        var fakePersonTwo = new FakeTestingPersonBuilder().Build();
+        await testingServiceScope.InsertAsync(fakePersonOne, fakePersonTwo);
+        
+        var input = $"""{nameof(TestingPerson.BirthMonth)} == "January" && {nameof(TestingPerson.Title)} == "{fakePersonOne.Title}" """;
+        
+        // Act
+        var queryablePeople = testingServiceScope.DbContext().People;
+        var appliedQueryable = queryablePeople.ApplyQueryKitFilter(input);
+        var people = await appliedQueryable.ToListAsync();
+
+        // Assert
+        people.Count.Should().Be(1);
+        people[0].Id.Should().Be(fakePersonOne.Id);
+    }
+    
+    [Fact]
+    public async Task can_filter_by_in_enum_names()
+    {
+        // Arrange
+        var testingServiceScope = new TestingServiceScope();
+        var faker = new Faker();
+        var fakePersonOne = new FakeTestingPersonBuilder()
+            .WithTitle(faker.Lorem.Sentence())
+            .WithBirthMonth(BirthMonthEnum.January)
+            .Build();
+        var fakePersonTwo = new FakeTestingPersonBuilder().Build();
+        await testingServiceScope.InsertAsync(fakePersonOne, fakePersonTwo);
+        
+        var input = $"""{nameof(TestingPerson.BirthMonth)} ^^ ["January", "March"] && {nameof(TestingPerson.Title)} == "{fakePersonOne.Title}" """;
+        
+        // Act
+        var queryablePeople = testingServiceScope.DbContext().People;
+        var appliedQueryable = queryablePeople.ApplyQueryKitFilter(input);
+        var people = await appliedQueryable.ToListAsync();
+
+        // Assert
+        people.Count.Should().Be(1);
+        people[0].Id.Should().Be(fakePersonOne.Id);
+    }
+    
+    [Fact]
+    public async Task can_filter_by_enum_number()
+    {
+        // Arrange
+        var testingServiceScope = new TestingServiceScope();
+        var faker = new Faker();
+        var fakePersonOne = new FakeTestingPersonBuilder()
+            .WithTitle(faker.Lorem.Sentence())
+            .WithBirthMonth(BirthMonthEnum.June)
+            .Build();
+        var fakePersonTwo = new FakeTestingPersonBuilder().Build();
+        await testingServiceScope.InsertAsync(fakePersonOne, fakePersonTwo);
+        
+        var input = $"""{nameof(TestingPerson.BirthMonth)} == "6" && {nameof(TestingPerson.Title)} == "{fakePersonOne.Title}" """;
+        
+        // Act
+        var queryablePeople = testingServiceScope.DbContext().People;
+        var appliedQueryable = queryablePeople.ApplyQueryKitFilter(input);
+        var people = await appliedQueryable.ToListAsync();
+
+        // Assert
+        people.Count.Should().Be(1);
+        people[0].Id.Should().Be(fakePersonOne.Id);
+    }
+    
+    [Fact]
+    public async Task can_filter_by_in_enum_numbers()
+    {
+        // Arrange
+        var testingServiceScope = new TestingServiceScope();
+        var faker = new Faker();
+        var fakePersonOne = new FakeTestingPersonBuilder()
+            .WithTitle(faker.Lorem.Sentence())
+            .WithBirthMonth(BirthMonthEnum.January)
+            .Build();
+        var fakePersonTwo = new FakeTestingPersonBuilder().Build();
+        await testingServiceScope.InsertAsync(fakePersonOne, fakePersonTwo);
+        
+        var input = $"""{nameof(TestingPerson.BirthMonth)} ^^ ["1", "3"] && {nameof(TestingPerson.Title)} == "{fakePersonOne.Title}" """;
+        
+        // Act
+        var queryablePeople = testingServiceScope.DbContext().People;
+        var appliedQueryable = queryablePeople.ApplyQueryKitFilter(input);
+        var people = await appliedQueryable.ToListAsync();
+
+        // Assert
+        people.Count.Should().Be(1);
+        people[0].Id.Should().Be(fakePersonOne.Id);
+    }
 }

--- a/QueryKit.UnitTests/FilterParserTests.cs
+++ b/QueryKit.UnitTests/FilterParserTests.cs
@@ -208,7 +208,7 @@ public class FilterParserTests
         var input = """(Age ^^ [20, 30, 40]) && (BirthMonth ^^ ["January", "February", "March"]) || (Id ^^ ["6d623e92-d2cf-4496-a2df-f49fa77328ee"])""";
         var filterExpression = FilterParser.ParseFilter<TestingPerson>(input);
         filterExpression.ToString().Should()
-            .Be(""""x => ((value(System.Collections.Generic.List`1[System.Nullable`1[System.Int32]]).Contains(x.Age) AndAlso value(System.Collections.Generic.List`1[System.String]).Contains(x.BirthMonth)) OrElse value(System.Collections.Generic.List`1[System.Guid]).Contains(x.Id))"""");
+            .Be(""""x => ((value(System.Collections.Generic.List`1[System.Nullable`1[System.Int32]]).Contains(x.Age) AndAlso value(System.Collections.Generic.List`1[System.Nullable`1[QueryKit.WebApiTestProject.Entities.BirthMonthEnum]]).Contains(x.BirthMonth)) OrElse value(System.Collections.Generic.List`1[System.Guid]).Contains(x.Id))"""");
     }
     
     [Fact]
@@ -217,7 +217,16 @@ public class FilterParserTests
         var input = """BirthMonth ^^ ["January", "February", "March"]""";
         var filterExpression = FilterParser.ParseFilter<TestingPerson>(input);
         filterExpression.ToString().Should()
-            .Be(""""x => value(System.Collections.Generic.List`1[System.String]).Contains(x.BirthMonth)"""");
+            .Be(""""x => value(System.Collections.Generic.List`1[System.Nullable`1[QueryKit.WebApiTestProject.Entities.BirthMonthEnum]]).Contains(x.BirthMonth)"""");
+    }
+    
+    [Fact]
+    public void simple_in_operator_for_enum_code()
+    {
+        var input = """BirthMonth ^^ [1, 2, 3]""";
+        var filterExpression = FilterParser.ParseFilter<TestingPerson>(input);
+        filterExpression.ToString().Should()
+            .Be(""""x => value(System.Collections.Generic.List`1[System.Nullable`1[QueryKit.WebApiTestProject.Entities.BirthMonthEnum]]).Contains(x.BirthMonth)"""");
     }
 
     [Fact]


### PR DESCRIPTION
Hi, I noticed the CI was failing, so I've attempted to fix that under commit [f9ec13d](https://github.com/pdevito3/QueryKit/commit/f9ec13d2c7d4026c1096b18a79a3f7ce6d2b0ea7).

Once I had the CI running again there were two unit tests failing (`test_in_operator` and `simple_in_operator_for_string`), which were both failing due to filtering by enums using the 'in' filter.

These look like they had been failing for a while, I couldn't pinpoint exactly when they started failing though, I was getting xUnit errors when trying to run the tests on older commits, probably something I haven't set up on my machine though.

The problem seemed to be when you filtered by an array of enums, e.g. `birthmonth ^^ ["January", "March"]`, it recognised the type as an enum, but just tried to run the array string directly through `Enum.Parse`. I've updated the logic to detect if it is an array in the same way arrays of strings are detected in the FilterParser, and then individually parse each Enum entry. This looks like it fixes it, but still required the unit tests to be updated to reflect the new types. This was all done under commit [783b387](https://github.com/pdevito3/QueryKit/commit/783b387c47fcaa58037633c2488362d6b38908b1).

Finally I just wanted to make sure I hadn't broken any functionality with any of this, so I've added some integration tests to cover some `Enum` scenarios under commit [662ff59](https://github.com/pdevito3/QueryKit/commit/662ff591dee8a012dc3a1e3c74da77720139c335). The tests compare enums, but also against a faked title just to avoid getting a whole load of other entries with matching enums, not sure if this is the best way to do it, happy to change it if there's a better approach.

These changes around Enums will probably cause conflicts with my other merge #28, so I'll have to update that if you accept this pull request.

Hope these changes all make sense!

Thanks.
