### PR TITLE
Fix collections filtering not working when custom properties set

### DIFF
--- a/QueryKit.UnitTests/CustomFilterPropertyTests.cs
+++ b/QueryKit.UnitTests/CustomFilterPropertyTests.cs
@@ -188,6 +188,38 @@ public class CustomFilterPropertyTests
     }
     
     [Fact]
+    public void can_have_custom_prop_work_with_collection_filters()
+    {
+        var faker = new Faker();
+        var stringValue = faker.Lorem.Word();
+        var input = $"""special_title == "{stringValue}" && Ingredients.Name == "flour" """;
+
+        var config = new QueryKitConfiguration(config =>
+        {
+            config.Property<Recipe>(x => x.Title).HasQueryName("special_title");
+        });
+        var filterExpression = FilterParser.ParseFilter<Recipe>(input, config);
+        filterExpression.ToString().Should().Be(
+            $"""x => ((x.Title == "{stringValue}") AndAlso x.Ingredients.Select(y => y.Name).Any(z => (z == "flour")))""");
+    }
+    
+    [Fact]
+    public void can_have_derived_prop_work_with_collection_filters()
+    {
+        var faker = new Faker();
+        var stringValue = faker.Lorem.Word();
+        var input = $"""special_title_directions == "{stringValue}" && Ingredients.Name == "flour" """;
+
+        var config = new QueryKitConfiguration(config =>
+        {
+            config.DerivedProperty<Recipe>(x => x.Title + x.Directions).HasQueryName("special_title_directions");
+        });
+        var filterExpression = FilterParser.ParseFilter<Recipe>(input, config);
+        filterExpression.ToString().Should().Be(
+            $"""x => (((x.Title + x.Directions) == "{stringValue}") AndAlso x.Ingredients.Select(y => y.Name).Any(z => (z == "flour")))""");
+    }
+    
+    [Fact]
     public void filter_prevented_props_always_have_true_equals_true_regardless_of_comparison()
     {
         var faker = new Faker();

--- a/QueryKit/ParameterReplacer.cs
+++ b/QueryKit/ParameterReplacer.cs
@@ -13,7 +13,12 @@ internal class ParameterReplacer : ExpressionVisitor
 
     protected override Expression VisitParameter(ParameterExpression node)
     {
-        // Replace all parameters with the new parameter
-        return _newParameter;
+        // Replace all parameters of the same type with the new parameter
+        if (node.Type == _newParameter.Type)
+        {
+            return _newParameter;
+        }
+
+        return base.VisitParameter(node);
     }
 }


### PR DESCRIPTION
Hey @pdevito3,

First of all I would like to thank you for the great effort maintaining the library.

There is a bug when setting custom or derived properties, collection filtering stops working because the `ParameterReplacer` replaces the nested parameter types. This PR addresses this issue and adds some unit tests to prevent breaking in the future. 

If you comment out the additions on `ParameterReplacer` you will get the error saying `Property 'System.String Name' is not defined for type 'QueryKit.WebApiTestProject.Entities.Recipes.Recipe'` because it tries to look up the Ingredient's Name on the `Recipe` type and not the `Ingredient`.

Any comments are welcomed!