### PR TITLE
Make ParseSort public

### DIFF
--- a/QueryKit/SortParser.cs
+++ b/QueryKit/SortParser.cs
@@ -17,7 +17,7 @@ public static class SortParser
     private const string Ascending = "asc";
     private const string Descending = "desc";
 
-    internal static List<SortExpressionInfo<T>> ParseSort<T>(string input, IQueryKitConfiguration? config = null)
+    public static List<SortExpressionInfo<T>> ParseSort<T>(string input, IQueryKitConfiguration? config = null)
     {
         if(string.IsNullOrWhiteSpace(input))
             return new List<SortExpressionInfo<T>>();


### PR DESCRIPTION
Our service layer expects Expressions for projections and sorting. So I use `FilterParser.ParseFilter` insead of `ApplyQueryKitFilter`
I want to apply the same approach for sorting, but `SortParser.ParseSort` is currently internal. Its seems its safe to make this public since `FilterParser.ParseFilter` is also public. 